### PR TITLE
feat: rename function from pg_sync_roles to sync_roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install pg-sync-roles psycopg
 To give a user CONNECT privileges on a database, as well as membership of role:
 
 ```python
-from pg_sync_roles import DatabaseConnect, RoleMembership, pg_sync_roles
+from pg_sync_roles import DatabaseConnect, RoleMembership, sync_roles
 
 # For example purposes, PostgreSQL can be run locally using this...
 # docker run --rm -it -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres
@@ -36,7 +36,7 @@ from pg_sync_roles import DatabaseConnect, RoleMembership, pg_sync_roles
 engine = sa.create_engine('postgresql+psycopg://postgres@127.0.0.1:5432/')
 
 with engine.begin() as conn:
-    pg_sync_roles(
+    sync_roles(
         conn,
         'my_user_name',
         grants=(
@@ -54,13 +54,13 @@ from pg_sync_roles import (
     SchemaUsage,
     SchemaOwnership,
     TableSelect,
-    pg_sync_roles,
+    sync_roles,
 )
 
 engine = sa.create_engine('postgresql+psycopg://postgres@127.0.0.1:5432/')
 
 with engine.begin() as conn:
-    pg_sync_roles(
+    sync_roles(
         conn,
         'my_role_name',
         grants=(

--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -1,2 +1,2 @@
-def pg_sync_roles():
+def sync_roles():
     pass

--- a/test_pg_sync_roles.py
+++ b/test_pg_sync_roles.py
@@ -1,6 +1,6 @@
-from pg_sync_roles import pg_sync_roles
+from pg_sync_roles import sync_roles
 
 
-def test_pg_sync_roles():
-    pg_sync_roles()
+def test_sync_roles():
+    sync_roles()
     assert True


### PR DESCRIPTION
Having the "pg_" bit in the function name felt a bit redundant/overly verbose somehow