### PR TITLE
feat: support wrapped connections

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -32,7 +32,10 @@ class RoleMembership:
 
 def sync_roles(conn, role_name, grants=(), lock_key=1):
     def execute_sql(sql_obj):
-        return conn.execute(sa.text(sql_obj.as_string(conn.connection.driver_connection)))
+        # This avoids "argument 1 must be psycopg2.extensions.connection, not PGConnectionProxy"
+        # which can happen when elastic-apm wraps the connection object when using psycopg2
+        unwrapped_connection = getattr(conn.connection.driver_connection, '__wrapped__', conn.connection.driver_connection)
+        return conn.execute(sa.text(sql_obj.as_string(unwrapped_connection)))
 
     @contextmanager
     def transaction():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,13 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=7.4.4",
+  "wrapt>=14.1",
 ]
 ci = [
   "pytest==7.4.4",
+  # At the time of writing, 1.14.1 is the latest version of wrapt that the latest version of
+  # elastic-apm can be installed with
+  "wrapt==1.14.1",
   "pytest-cov",
 ]
 ci-psycopg2-sqlalchemy1 = [


### PR DESCRIPTION
As the comment suggests, elastic-apm seems to wrap connections which fails sql.SQL with

> "argument 1 must be psycopg2.extensions.connection, not PGConnectionProxy"

So we unwrap before passing to as_string.