### PR TITLE
feat: revoke permissions from sequences

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -521,6 +521,7 @@ _TABLE_LIKE = {
     'materialized view',
     'foreign table',
     'partitioned table',
+    'sequence',
 }
 
 


### PR DESCRIPTION
This hopefully completes the revocation of all ACL permissions from pg_class, so all table-like objects.