### PR TITLE
perf: faster check on existing permissions

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -548,10 +548,11 @@ WHERE oid = quote_ident({role_name})::regrole
 UNION ALL
 
 -- Direct role memberships
-SELECT 'role' AS on, rolname AS name_1, NULL AS name_2, NULL AS name_3, 'MEMBER' AS privilege_type
-FROM pg_auth_members m
-INNER JOIN pg_roles r ON r.oid = m.roleid
-WHERE m.member = quote_ident({role_name})::regrole
+SELECT 'role' AS on, groups.rolname AS name_1, NULL AS name_2, NULL AS name_3, 'MEMBER' AS privilege_type
+FROM pg_auth_members mg
+INNER JOIN pg_roles groups ON groups.oid = mg.roleid
+INNER JOIN pg_roles members ON members.oid = mg.member
+WHERE members.rolname = {role_name}
 
 UNION ALL
 


### PR DESCRIPTION
By removing the cast to ::regrole in this part of the query, it avoids a full table scan on pg_authid and shaves a few milliseconds from querying permissions. On a fairly complex database this leaves finding existing permissions of a role at around 8ms.