### PR TITLE
refactor: more consistent naming and usage of data classes

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -356,8 +356,8 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
         # Ownerships to grant and revoke
         existing_schema_ownerships = tuple(perm['name_1'] for perm in existing_permissions if perm['on'] == 'schema')
-        schema_ownership_names_exact = set(schema_ownership.schema_name for schema_ownership in schema_ownerships)
-        schema_names_to_revoke_ownership = tuple(schema_name for schema_name in existing_schema_ownerships if schema_name not in schema_ownership_names_exact)
+        schema_ownership_names = set(schema_ownership.schema_name for schema_ownership in schema_ownerships)
+        schema_names_to_revoke_ownership = tuple(schema_name for schema_name in existing_schema_ownerships if schema_name not in schema_ownership_names)
         schema_ownerships_to_grant_ownership = tuple(schema_ownership for schema_ownership in schema_ownerships if schema_ownership.schema_name not in existing_schema_ownerships)
 
         # And any memberships of the database connect roles or explicitly requested role memberships
@@ -421,8 +421,8 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
         # Grant or revoke schema ownerships
         existing_schema_ownerships = tuple(perm['name_1'] for perm in existing_permissions if perm['on'] == 'schema')
-        schema_ownership_names_exact = set(schema_ownership.schema_name for schema_ownership in schema_ownerships)
-        schema_names_to_revoke_ownership = tuple(schema_name for schema_name in existing_schema_ownerships if schema_name not in schema_ownership_names_exact)
+        schema_ownership_names = set(schema_ownership.schema_name for schema_ownership in schema_ownerships)
+        schema_names_to_revoke_ownership = tuple(schema_name for schema_name in existing_schema_ownerships if schema_name not in schema_ownership_names)
         schema_ownerships_to_grant_ownership = tuple(schema_ownership for schema_ownership in schema_ownerships if schema_ownership.schema_name not in existing_schema_ownerships)
         for schema_name in schema_names_to_revoke_ownership:
             revoke_schema_ownership(schema_name)

--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -338,10 +338,10 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
         table_selects = tuple(table_select for table_select in table_selects if (table_select.schema_name, table_select.table_name) in tables_that_exist)
 
         # Find if we need to make the role
-        role_needed = not get_role_exists(role_name)
+        role_to_create = not get_role_exists(role_name)
 
         # Get all existing permissions
-        existing_permissions = get_existing_permissions(role_name) if not role_needed else []
+        existing_permissions = get_existing_permissions(role_name) if not role_to_create else []
 
         # Real ACL permissions - we revoke them all
         acl_permissions_to_revoke = get_acl_rows(existing_permissions)
@@ -383,7 +383,7 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
         # If we don't need to do anything, we're done.
         if (
-            not role_needed
+            not role_to_create
             and not database_connect_roles_needed
             and not schema_usage_roles_needed
             and not table_select_roles_needed
@@ -404,8 +404,8 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
         lock()
 
         # Make the role if we need to
-        role_needed = not get_role_exists(role_name)
-        if role_needed:
+        role_to_create = not get_role_exists(role_name)
+        if role_to_create:
             create_role(role_name)
 
         # Find existing objects where needed


### PR DESCRIPTION
Making it so variables...

- end in `_to_create` if there for something to be created
- end in `_to_grant` if there for something to be granted
- end in `_to_revoke` if there is something to be revoked.

Also uses data classes internally a touch more