### PR TITLE
feat: work not as superuser - as in RDS

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -222,7 +222,15 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
     def grant_schema_ownership(role_name, schema_name):
         logger.info("Granting OWNERSHIP on schema %s to role %s", schema_name, role_name)
+        execute_sql(sql.SQL('GRANT {role_name} TO SESSION_USER').format(
+            role_name=sql.Identifier(role_name),
+            schema_name=sql.Identifier(schema_name),
+        ))
         execute_sql(sql.SQL('ALTER SCHEMA {schema_name} OWNER TO {role_name}').format(
+            role_name=sql.Identifier(role_name),
+            schema_name=sql.Identifier(schema_name),
+        ))
+        execute_sql(sql.SQL('REVOKE {role_name} FROM SESSION_USER').format(
             role_name=sql.Identifier(role_name),
             schema_name=sql.Identifier(schema_name),
         ))
@@ -243,7 +251,15 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
     def revoke_schema_ownership(schema_name):
         logger.info("Revoking schema ownership of %s from role %s", schema_name, role_name)
+        execute_sql(sql.SQL('GRANT {role_name} TO SESSION_USER').format(
+            role_name=sql.Identifier(role_name),
+            schema_name=sql.Identifier(schema_name),
+        ))
         execute_sql(sql.SQL('ALTER SCHEMA {schema_name} OWNER TO SESSION_USER').format(
+            schema_name=sql.Identifier(schema_name),
+        ))
+        execute_sql(sql.SQL('REVOKE {role_name} FROM SESSION_USER').format(
+            role_name=sql.Identifier(role_name),
             schema_name=sql.Identifier(schema_name),
         ))
 


### PR DESCRIPTION
 The main user in RDS is _not_ a superuser, and so we should make sure to work as superuser.

The only thing that's different is that to grant ownership of a role, then the current user has to be a member of that role