### PR TITLE
feat: preserve privileges in team schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ with engine.connect() as conn:
 
 ### Core function
 
-#### `sync_roles(conn, role_name, grants=(), lock_key=1)`
+#### `sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(), lock_key=1)`
 
 - `conn`
 
@@ -117,6 +117,12 @@ with engine.connect() as conn:
 - `grants=()`
 
    A tuple of grants of all permissions that the role specified by the `role_name` should have. Anything not in this list will be automatically revoked. See [Grant types](#grant-types) for the list of grant types.
+
+- `preserve_existing_grants_in_schemas=()`
+
+   A tuple of schema names. For each schema name `sync_roles` will leave any existing privileges granted on anything in the schema to `role_name` intact. This is useful in situations when the contents of the schemas are managed separately, outside of calls to `sync_roles`.
+
+   A schema name being listed in `preserve_existing_grants_in_schemas` does not affect management of permissions on the the schema itself. In order for `role_name` to have privileges on these, they will have to be passed in via the `grants` parameter.
 
 - `lock_key=1`
 


### PR DESCRIPTION
pg-sync-roles doesn't yet have the ability to handle all use cases, and specifically certain situations of "team schemas" such as those in Data Workspace, where many users should have access to everything in a schema, even ones created in the future, after any call to sync_roles. Specifically, the sync_roles function would revoke access to tables in team schemas.

To work around this, this change adds the ability to ignore all objects in certain schemas, and so not revoke access to them.