### PR TITLE
feat: handle null ACL when objects are created

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -676,7 +676,7 @@ UNION ALL
   FROM pg_class c
   INNER JOIN pg_namespace n ON n.oid = c.relnamespace
   INNER JOIN owned_or_acl a ON a.objid = c.oid
-  CROSS JOIN aclexplode(c.relacl)
+  CROSS JOIN aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner)))
   INNER JOIN relkind_mapping r ON r.relkind = c.relkind
   WHERE classid = 'pg_class'::regclass AND grantee = refobjid AND objsubid = 0
 )


### PR DESCRIPTION
When objects are first created, their ACL is null (assuming no default ACL has been set otherwise via ALTER DEFAULT PRIVILEGES). In this case, the owner of the object in question has privileges corresponding to acldefault. So, when listing existing privileges we need to consult acldefault.