### PR TITLE
feat: use CURRENT_USER everywhere

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -226,7 +226,7 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
 
     def grant_ownership(object_type, role_name, object_name):
         logger.info("Granting OWNERSHIP on %s %s to role %s", object_type, object_name, role_name)
-        execute_sql(sql.SQL('GRANT {role_name} TO SESSION_USER').format(
+        execute_sql(sql.SQL('GRANT {role_name} TO CURRENT_USER').format(
             role_name=sql.Identifier(role_name),
         ))
         execute_sql(sql.SQL('ALTER {object_type} {object_name} OWNER TO {role_name}').format(
@@ -234,20 +234,20 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
             role_name=sql.Identifier(role_name),
             object_name=sql.Identifier(object_name),
         ))
-        execute_sql(sql.SQL('REVOKE {role_name} FROM SESSION_USER').format(
+        execute_sql(sql.SQL('REVOKE {role_name} FROM CURRENT_USER').format(
             role_name=sql.Identifier(role_name),
         ))
 
     def revoke_ownership(object_type, role_name, object_name):
         logger.info("Revoking schema ownership of %s %s from role %s", object_type, object_name, role_name)
-        execute_sql(sql.SQL('GRANT {role_name} TO SESSION_USER').format(
+        execute_sql(sql.SQL('GRANT {role_name} TO CURRENT_USER').format(
             role_name=sql.Identifier(role_name),
         ))
-        execute_sql(sql.SQL('ALTER {object_type} {object_name} OWNER TO SESSION_USER').format(
+        execute_sql(sql.SQL('ALTER {object_type} {object_name} OWNER TO CURRENT_USER').format(
             object_type=object_type,
             object_name=sql.Identifier(object_name),
         ))
-        execute_sql(sql.SQL('REVOKE {role_name} FROM SESSION_USER').format(
+        execute_sql(sql.SQL('REVOKE {role_name} FROM CURRENT_USER').format(
             role_name=sql.Identifier(role_name),
         ))
 
@@ -291,7 +291,7 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
         if perm['privilege_type'] not in _KNOWN_PRIVILEGES:
             raise RuntimeError('Unknown privilege')
 
-        session_user = execute_sql(sql.SQL('SELECT SESSION_USER')).fetchall()[0][0]
+        CURRENT_USER = execute_sql(sql.SQL('SELECT CURRENT_USER')).fetchall()[0][0]
         table_owner = execute_sql(sql.SQL(
             '''
             SELECT rolname FROM pg_class c
@@ -305,8 +305,8 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
             table_name=sql.Literal(perm['name_2']),
         )).fetchall()[0][0]
 
-        if session_user != table_owner:
-            execute_sql(sql.SQL('GRANT {table_owner} TO SESSION_USER').format(
+        if CURRENT_USER != table_owner:
+            execute_sql(sql.SQL('GRANT {table_owner} TO CURRENT_USER').format(
                 table_owner=sql.Identifier(table_owner)
             ))
 
@@ -317,8 +317,8 @@ def sync_roles(conn, role_name, grants=(), lock_key=1):
             role_name=sql.Identifier(role_name),
         ))
 
-        if session_user != table_owner:
-            execute_sql(sql.SQL('REVOKE {table_owner} FROM SESSION_USER').format(
+        if CURRENT_USER != table_owner:
+            execute_sql(sql.SQL('REVOKE {table_owner} FROM CURRENT_USER').format(
                 table_owner=sql.Identifier(table_owner)
             ))
 

--- a/test_pg_sync_roles.py
+++ b/test_pg_sync_roles.py
@@ -777,7 +777,7 @@ def test_schema_ownership_can_be_revoked(test_engine, test_table):
         sync_roles(conn, role_name, grants=())
 
     with test_engine.connect() as conn:
-        assert conn.execute(sa.text(f"SELECT nspowner::regrole::name = SESSION_USER FROM pg_namespace WHERE nspname='{schema_name}'")).fetchall()[0][0]
+        assert conn.execute(sa.text(f"SELECT nspowner::regrole::name = CURRENT_USER FROM pg_namespace WHERE nspname='{schema_name}'")).fetchall()[0][0]
 
 def test_ownership_if_schema_does_not_exist(test_engine):
     schema_name = 'test_schema_' + uuid.uuid4().hex
@@ -834,14 +834,14 @@ def test_direct_table_permission_can_be_revoked_when_not_owner(test_engine, test
         # to test_name_2. But in order to to that we have
 
         # ... grant role_name_1 to the session user to able assign it ownership
-        conn.execute(sa.text(f'GRANT {role_name_1} TO SESSION_USER'))
+        conn.execute(sa.text(f'GRANT {role_name_1} TO CURRENT_USER'))
         # ... and give it CREATE privileges to be able to own anything in the schema
         conn.execute(sa.text(f'GRANT CREATE ON SCHEMA {schema_name} TO {role_name_1}'))
         conn.execute(sa.text(f'GRANT SELECT ON TABLE {schema_name}.{table_name} TO {role_name_2}'))
         conn.execute(sa.text(f'ALTER TABLE {schema_name}.{table_name} OWNER TO {role_name_1}'))
 
         # .. and then tidy up the temporary perms
-        conn.execute(sa.text(f'REVOKE {role_name_1} FROM SESSION_USER'))
+        conn.execute(sa.text(f'REVOKE {role_name_1} FROM CURRENT_USER'))
         conn.execute(sa.text(f'REVOKE CREATE ON SCHEMA {schema_name} FROM {role_name_1}'))
 
         conn.commit()


### PR DESCRIPTION
It more appropriate to use CURRENT_USER - this is the user _after_ any SET ROLE has been performed, and the one used for permissions checking.