### PR TITLE
fix: allow grant on schemas even if not owner

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -515,12 +515,12 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         # we need to check if the current use is the owner, and grant the owner to the user if not
         current_user = execute_sql(sql.SQL('SELECT CURRENT_USER')).fetchall()[0][0]
 
-        with temporary_grant_of(role_name):
+        # Find existing objects where needed
+        databases_that_exist = set(get_existing('pg_database', 'datname', all_database_names))
+        schemas_that_exist = set(get_existing('pg_namespace', 'nspname', all_schema_names))
+        tables_that_exist = set(get_existing_in_schema('pg_class', 'relnamespace', 'relname', all_table_names))
 
-            # Find existing objects where needed
-            databases_that_exist = set(get_existing('pg_database', 'datname', all_database_names))
-            schemas_that_exist = set(get_existing('pg_namespace', 'nspname', all_schema_names))
-            tables_that_exist = set(get_existing_in_schema('pg_class', 'relnamespace', 'relname', all_table_names))
+        with temporary_grant_of(role_name):
 
             # Get all existing permissions
             existing_permissions = get_existing_permissions(role_name, preserve_existing_grants_in_schemas)

--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -520,10 +520,10 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         schemas_that_exist = set(get_existing('pg_namespace', 'nspname', all_schema_names))
         tables_that_exist = set(get_existing_in_schema('pg_class', 'relnamespace', 'relname', all_table_names))
 
-        with temporary_grant_of(role_name):
+        # Get all existing permissions
+        existing_permissions = get_existing_permissions(role_name, preserve_existing_grants_in_schemas)
 
-            # Get all existing permissions
-            existing_permissions = get_existing_permissions(role_name, preserve_existing_grants_in_schemas)
+        with temporary_grant_of(role_name):
 
             # Grant or revoke schema ownerships
             schema_ownerships_that_exist = tuple(SchemaOwnership(perm['name_1']) for perm in existing_permissions if perm['on'] == 'schema')


### PR DESCRIPTION
 This change allow the grants on objects even if the current user is not the owner of the object. It does this by granting itself the owner role for any object if necessary.