### PR TITLE
feat: revoke direct privileges on schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ with engine.connect() as conn:
     )
 ```
 
-Or to give a role SELECT on a table, USAGE on a schema, membersip of a role, and OWNERship of another schema:
+Or to give a role SELECT on a table, USAGE on its schema, membersip of a role, and OWNERship+USAGE+CREATE of another schema:
 
 ```python
 from pg_sync_roles import (
     RoleMembership,
     SchemaUsage,
+    SchemaCreate,
     SchemaOwnership,
     TableSelect,
     sync_roles,
@@ -91,10 +92,12 @@ with engine.connect() as conn:
         conn,
         'my_role_name',
         grants=(
-            TableSelect('my_schema', 'my_table'),
             SchemaUsage('my_schema'),
-            RoleMembership('my_other_role'),
+            TableSelect('my_schema', 'my_table'),
             SchemaOwnership('my_other_schema'),
+            SchemaUsage('my_other_schema'),
+            SchemaCreate('my_other_schema'),
+            RoleMembership('my_other_role'),
         ),
     )
 ```


### PR DESCRIPTION
This I think has revealed some oddities when managing objects in schemas on which the syncing user doesn't have USAGE permission, which is revoked automatically when a schema's ownership is transferred to another user. Specifically, the syncing user then can't even see tables in the schema.

The best-effort change work around here is to grant itself the owner role of the schemas to try to get USAGE on them.

I am starting to suspect that ownership of schemas is a bit tricky to be delegated. Granting USAGE and CREATE is probably the way to go to allow roles to create things in them.