### PR TITLE
refactor: use correct variable name in function

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -244,7 +244,7 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
 
     def get_acl_roles_in_schema(privilege_type, table_name, row_name_column_name, acl_column_name, namespace_oid_column_name, role_pattern, row_names):
         row_name_role_names = \
-            [] if not table_selects else \
+            [] if not row_names else \
             execute_sql(sql.SQL("""
                 SELECT all_names.schema_name, all_names.row_name, grantee::regrole
                 FROM (


### PR DESCRIPTION
This changes one of the internal functions to use the variable passed to it, rather than the one in the surrounding scope.

It shouldn't change any functionality, the only use of the variable is to cast it to a bool, and the variables are always the same in terms of their truthyness.