### PR TITLE
ci: test on more Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ The names of the roles maintained by pg-sync-roles begin with the prefix `_pgsr_
 
 pg-sync-roles aims to be compatible with a wide range of Python and other dependencies:
 
-- Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
+- Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, 3.11.0, 3.12.0 and 3.13.0)
 - psycopg2 >= 2.9.2 (tested on 3.9.2) and Psycopg 3 >= 3.1.4 (tested on 3.1.4)
-- SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
+- SQLAlchemy >= 1.4.24, other than between 2.0.0 and 2.0.30 on Python 3.13 (tested on 1.4.24 and 2.0.0 on Python < 3.13, or 2.0.31 on Python 3.13)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 and 17.0)
 
 Note that SQLAlchemy < 2 does not support Psycopg 3, and for SQLAlchemy < 2 `future=True` must be passed to its create_engine function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,17 @@ ci-psycopg2-sqlalchemy2 = [
     "psycopg2==2.9.2",
     "sqlalchemy==2.0.0",
 ]
+ci-psycopg2-sqlalchemy2-0-31 = [
+    "psycopg2==2.9.2",
+    "sqlalchemy==2.0.31",
+]
 ci-psycopg3-sqlalchemy2 = [
     "psycopg==3.1.4",
     "sqlalchemy==2.0.0",
+]
+ci-psycopg3-sqlalchemy2-0-31 = [
+    "psycopg==3.1.4",
+    "sqlalchemy==2.0.31",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
 This is slightly complicated because SQLAlchemy versions between 2.0.0 and 2.0.30 don't work on Python 3.13