### PR TITLE
ci: test on more Python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
           - "3.9.0"
           - "3.10.0"
           - "3.11.0"
+          - "3.12.0"
         postgresql-version:
           - "postgres:9.6"
           - "postgres:10.0"
@@ -31,6 +32,13 @@ jobs:
           - ci-psycopg2-sqlalchemy1
           - ci-psycopg2-sqlalchemy2
           - ci-psycopg3-sqlalchemy2
+        include:
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy1
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg2-9-10-sqlalchemy2-0-31
+          - python-version: "3.13.0"
+            ci-extras: ci-psycopg3-sqlalchemy2-0-31
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"

--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ The names of the roles maintained by pg-sync-roles begin with the prefix `_pgsr_
 
 pg-sync-roles aims to be compatible with a wide range of Python and other dependencies:
 
-- Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, and 3.11.0)
-- psycopg2 >= 2.9.2 (tested on 2.9.2) and Psycopg 3 >= 3.1.4 (tested on 3.1.4)
-- SQLAlchemy >= 1.4.24 (tested on 1.4.24 and 2.0.0)
+- Python >= 3.7.1 (tested on 3.7.1, 3.8.0, 3.9.0, 3.10.0, 3.11.0, 3.12.0 and 3.13.0)
+- psycopg2 >= 2.9.2 for Python < 3.13.0 (tested on 3.9.2), or psycopg2 >= 2.9.10 for Python 3.13 (tested on 2.9.10) and Psycopg 3 >= 3.1.4 for all supported versions of Python (tested on 3.1.4)
+- SQLAlchemy >= 1.4.24, other than between 2.0.0 and 2.0.30 on Python 3.13 (tested on 1.4.24 and 2.0.0 for Python < 3.13.0, and 2.0.31 for Python 3.13.0)
 - PostgreSQL >= 9.6 (tested on 9.6, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 and 17.0)
 
 Note that SQLAlchemy < 2 does not support Psycopg 3, and for SQLAlchemy < 2 `future=True` must be passed to its create_engine function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,25 @@ ci-psycopg2-sqlalchemy1 = [
     "psycopg2==2.9.2",
     "sqlalchemy==1.4.24",
 ]
+ci-psycopg2-9-10-sqlalchemy1 = [
+    "psycopg2==2.9.10",
+    "sqlalchemy==1.4.24",
+]
 ci-psycopg2-sqlalchemy2 = [
     "psycopg2==2.9.2",
     "sqlalchemy==2.0.0",
 ]
+ci-psycopg2-9-10-sqlalchemy2-0-31 = [
+    "psycopg2==2.9.10",
+    "sqlalchemy==2.0.31",
+]
 ci-psycopg3-sqlalchemy2 = [
     "psycopg==3.1.4",
     "sqlalchemy==2.0.0",
+]
+ci-psycopg3-sqlalchemy2-0-31 = [
+    "psycopg==3.1.4",
+    "sqlalchemy==2.0.31",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
This is slightly complicated because SQLAlchemy versions between 2.0.0 and 2.0.30 don't work on Python 3.13