### PR TITLE
feat: direct mode for schema create permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ A more [complex example of using multiple calls to `sync_roles` can be found in 
 
 #### `SchemaUsage(schema_name, direct=False)`
 
-#### `SchemaCreate(schema_name)`
+#### `SchemaCreate(schema_name, direct=False)`
 
 #### `TableSelect(schema_name, table_name, direct=False)`
 
@@ -304,7 +304,7 @@ The advisory lock is only obtained if `sync_roles` detects there are changes to 
 
 The default behaviour for pg-sync-roles is to maintain a role per database permission, a role per schema permission, and a role per table permission. Rather than roles being granted permissions directly on objects, membership is granted to these roles that indirectly grant permissions on objects. This means that from the object's point of view, only 1 role has any given permission. This works around the de-facto limit on the number of roles that can have permission to any object.
 
-If the `TableSelect` and `SchemaUsage` grant types are constructed with `direct=True`, then the role is granted permission directly on the object without use of an intermediate role. This can be useful to minimise the number of role memberships; in some cases [a high number of role memberships can result in the connecting user taking an extremely long time to connect to the database](https://www.postgresql.org/message-id/CAJe2WWhxzbt_uszVYnyfw4Y%2BOdeHXdue0GD%2BOd5uk15XD_FL5w%40mail.gmail.com).
+If the `TableSelect`, `SchemaUsage` or `SchemaCreate` grant types are constructed with `direct=True`, then the role is granted permission directly on the object without use of an intermediate role. This can be useful to minimise the number of role memberships; in some cases [a high number of role memberships can result in the connecting user taking an extremely long time to connect to the database](https://www.postgresql.org/message-id/CAJe2WWhxzbt_uszVYnyfw4Y%2BOdeHXdue0GD%2BOd5uk15XD_FL5w%40mail.gmail.com).
 
 The names of the roles maintained by pg-sync-roles begin with the prefix `_pgsr_`. Each name ends with a randomly generated unique identifier.
 
@@ -410,7 +410,7 @@ Also having high numbers of grantees on each object makes full table scans on th
 
 ### Avoiding usage of intermediate roles for some cases
 
-For table SELECT and schema USAGE, the grant types support a `direct=True` mode that avoids the intermediate roles. This is because we had a system where for users with high numbers of intermediate roles, two to three thousand, "sometimes" it would take > 90 seconds to initiate a connection to the database, while users with low numbers of roles would consistently connect almost instantly.
+For table SELECT, schema USAGE, and schema CREATE, the grant types support a `direct=True` mode that avoids the intermediate roles. This is because we had a system where for users with high numbers of intermediate roles, two to three thousand, "sometimes" it would take > 90 seconds to initiate a connection to the database, while users with low numbers of roles would consistently connect almost instantly.
 
 The reasons for this was never discovered, and exactly what "sometimes" was never pinned down — although calling CREATE ROLE seemed to be highly corrolated with subsequent slow connection times. However, since this setup had thousands of roles and _millions_ of rows in `pg_auth_members`, it felt like a situation that PostgreSQL was not designed for. By judicious use of `direct=True`, we could reduce the amount of role memberships for users by 1-2 orders of magnitude.
 

--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -67,6 +67,7 @@ class SchemaUsage:
 @dataclass(frozen=True)
 class SchemaCreate:
     schema_name: str
+    direct: bool = False
 
 
 @dataclass(frozen=True)
@@ -412,7 +413,8 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
     database_connects = tuple(grant for grant in grants if isinstance(grant, DatabaseConnect))
     schema_usages_indirect = tuple(grant for grant in grants if isinstance(grant, SchemaUsage) and not grant.direct)
     schema_usages_direct = tuple(grant for grant in grants if isinstance(grant, SchemaUsage) and grant.direct)
-    schema_creates = tuple(grant for grant in grants if isinstance(grant, SchemaCreate))
+    schema_creates_indirect = tuple(grant for grant in grants if isinstance(grant, SchemaCreate) and not grant.direct)
+    schema_creates_direct = tuple(grant for grant in grants if isinstance(grant, SchemaCreate) and grant.direct)
     schema_ownerships = tuple(grant for grant in grants if isinstance(grant, SchemaOwnership))
     table_selects_indirect = tuple(grant for grant in grants if isinstance(grant, TableSelect) and not grant.direct)
     table_selects_direct = tuple(grant for grant in grants if isinstance(grant, TableSelect) and grant.direct)
@@ -443,12 +445,13 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         schema_ownerships_names = set(schema_ownership.schema_name for schema_ownership in schema_ownerships)
         schema_usages_indirect = tuple(schema_usage for schema_usage in schema_usages_indirect if (schema_usage.schema_name,) in schemas_that_exist or schema_usage.schema_name in schema_ownerships_names)
         schema_usages_direct = tuple(schema_usage for schema_usage in schema_usages_direct if (schema_usage.schema_name,) in schemas_that_exist or schema_usage.schema_name in schema_ownerships_names)
-        schema_creates = tuple(schema_create for schema_create in schema_creates if (schema_create.schema_name,) in schemas_that_exist or schema_create.schema_name in schema_ownerships_names)
+        schema_creates_indirect = tuple(schema_create for schema_create in schema_creates_indirect if (schema_create.schema_name,) in schemas_that_exist or schema_create.schema_name in schema_ownerships_names)
+        schema_creates_direct = tuple(schema_create for schema_create in schema_creates_direct if (schema_create.schema_name,) in schemas_that_exist or schema_create.schema_name in schema_ownerships_names)
         table_selects_indirect = tuple(table_select for table_select in table_selects_indirect if (table_select.schema_name, table_select.table_name) in tables_that_exist)
         table_selects_direct = tuple(table_select for table_select in table_selects_direct if (table_select.schema_name, table_select.table_name) in tables_that_exist)
         all_database_connect_names = tuple(grant.database_name for grant in database_connects)
         all_schema_usage_indirect_names = tuple(grant.schema_name for grant in schema_usages_indirect)
-        all_schema_create_names = tuple(grant.schema_name for grant in schema_creates)
+        all_schema_create_indirect_names = tuple(grant.schema_name for grant in schema_creates_indirect)
         all_table_select_indirect_names = tuple((grant.schema_name, grant.table_name) for grant in table_selects_indirect)
 
         # Find if we need to make the role
@@ -468,10 +471,12 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         # Real ACL permissions on schemas
         acl_schema_permissions_tuples = tuple((row['privilege_type'], row['name_1']) for row in get_acl_rows(existing_permissions, _SCHEMA))
         acl_schema_permissions_set = set(acl_schema_permissions_tuples)
-        schema_usages_direct_tuples = tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct)
-        schema_usages_direct_set = set(schema_usages_direct_tuples)
-        acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_usages_direct_set)
-        acl_schema_permissions_to_grant = tuple(row for row in schema_usages_direct_tuples if row not in acl_schema_permissions_set)
+        schema_direct_tuples = \
+            tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct) + \
+            tuple(('CREATE', schema_usage.schema_name) for schema_usage in schema_creates_direct)
+        schema_direct_set = set(schema_direct_tuples)
+        acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_direct_tuples)
+        acl_schema_permissions_to_grant = tuple(row for row in schema_direct_tuples if row not in acl_schema_permissions_set)
 
         # And the ACL-equivalent roles
         database_connect_roles = get_acl_roles(
@@ -485,7 +490,7 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         schema_usage_roles_to_create = keys_with_none_value(schema_usage_roles)
         schema_create_roles = get_acl_roles(
             'CREATE', 'pg_namespace', 'nspname', 'nspacl', f'\\_pgsr\\_local\\_{db_oid}_\\schema\\_create\\_%',
-            all_schema_create_names)
+            all_schema_create_indirect_names)
         schema_create_roles_to_create = keys_with_none_value(schema_create_roles)
 
         table_select_roles = get_acl_roles_in_schema(
@@ -576,10 +581,12 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         # Real ACL permissions on schemas
         acl_schema_permissions_tuples = tuple((row['privilege_type'], row['name_1']) for row in get_acl_rows(existing_permissions, _SCHEMA))
         acl_schema_permissions_set = set(acl_schema_permissions_tuples)
-        schema_usages_direct_tuples = tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct)
-        schema_usages_direct_set = set(schema_usages_direct_tuples)
-        acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_usages_direct_set)
-        acl_schema_permissions_to_grant = tuple(row for row in schema_usages_direct_tuples if row not in acl_schema_permissions_set)
+        schema_direct_tuples = \
+            tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct) + \
+            tuple(('CREATE', schema_usage.schema_name) for schema_usage in schema_creates_direct)
+        schema_direct_set = set(schema_direct_tuples)
+        acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_direct_tuples)
+        acl_schema_permissions_to_grant = tuple(row for row in schema_direct_tuples if row not in acl_schema_permissions_set)
 
         # Gather all changes to be made to objects - the current user must be owner of them
         schema_ownerships_that_exist = tuple(SchemaOwnership(perm['name_1']) for perm in existing_permissions if perm['on'] == 'schema' and perm['privilege_type'] == 'OWNER')
@@ -593,10 +600,9 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
             'USAGE', 'pg_namespace', 'nspname', 'nspacl', f'\\_pgsr\\_local\\_{db_oid}_\\schema\\_usage\\_%',
             all_schema_usage_indirect_names)
         schema_usage_roles_to_create = keys_with_none_value(schema_usage_roles)
-
         schema_create_roles = get_acl_roles(
             'CREATE', 'pg_namespace', 'nspname', 'nspacl', f'\\_pgsr\\_local\\_{db_oid}_\\schema\\_create\\_%',
-            all_schema_create_names)
+            all_schema_create_indirect_names)
         schema_create_roles_to_create = keys_with_none_value(schema_create_roles)
         table_select_roles = get_acl_roles_in_schema(
             'SELECT', 'pg_class', 'relname', 'relacl', 'relnamespace', f'\\_pgsr\\_local\\_{db_oid}_\\table\\_select\\_%',
@@ -681,10 +687,12 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
             # Real ACL permissions on schemas
             acl_schema_permissions_tuples = tuple((row['privilege_type'], row['name_1']) for row in get_acl_rows(existing_permissions, _SCHEMA))
             acl_schema_permissions_set = set(acl_schema_permissions_tuples)
-            schema_usages_direct_tuples = tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct)
-            schema_usages_direct_set = set(schema_usages_direct_tuples)
-            acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_usages_direct_set)
-            acl_schema_permissions_to_grant = tuple(row for row in schema_usages_direct_tuples if row not in acl_schema_permissions_set)
+            schema_direct_tuples = \
+                tuple(('USAGE', schema_usage.schema_name) for schema_usage in schema_usages_direct) + \
+                tuple(('CREATE', schema_usage.schema_name) for schema_usage in schema_creates_direct)
+            schema_direct_set = set(schema_direct_tuples)
+            acl_schema_permissions_to_revoke = tuple(row for row in acl_schema_permissions_tuples if row not in schema_direct_tuples)
+            acl_schema_permissions_to_grant = tuple(row for row in schema_direct_tuples if row not in acl_schema_permissions_set)
 
             # Revoke direct permissions on tables and schemas
             for perm in acl_table_permissions_to_revoke:


### PR DESCRIPTION
This adds a direct mode for the schema create permissions, which can be used to reduce the number of role memberships in a complex system.