### PR TITLE
perf: remove unnecessary queries after obtaining lock

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -594,11 +594,6 @@ def sync_roles(conn, role_name, grants=(), preserve_existing_grants_in_schemas=(
         # we need to check if the current use is the owner, and grant the owner to the user if not
         current_user = execute_sql(sql.SQL('SELECT CURRENT_USER')).fetchall()[0][0]
 
-        # Find existing objects where needed
-        databases_that_exist = set(get_existing('pg_database', 'datname', all_database_names))
-        schemas_that_exist = set(get_existing('pg_namespace', 'nspname', all_schema_names))
-        tables_that_exist = set(get_existing_in_schema('pg_class', 'relnamespace', 'relname', all_table_names))
-
         # Get all existing permissions
         existing_permissions = get_existing_permissions(role_name, preserve_existing_grants_in_schemas)
 


### PR DESCRIPTION
This removes re-checking if tables/schemas/database exist after obtaining lock.

This might technically very slightly increase the chance of errors if say a schema is removed during the run of sync_roles, but the lock is not for wrapping the removal of tables/schemas(/database...), and so we are already vulnerable to that in various ways I suspect. I am pro to think about how to sort that properly later, or leave that as out of scope and a possible risk that calling code has to deal with.