### PR TITLE
fix: login behaviours when valid_until is None and no password

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,12 @@ A more [complex example of using multiple calls to `sync_roles` can be found in 
 
 ### Grant types
 
-#### `Login(password, valid_until)`
+#### `Login(valid_until=Optional[datetime], password=Optional[str])`
+
+Gives the ability to login with `password` until `valid_until`.
+
+- If `valid_until` is `None`, then the role can login forever.
+- If `password` is `None`, then any existing password is preserved.
 
 #### `DatabaseConnect(database_name)`
 


### PR DESCRIPTION
This fixes behaviours around the Login grant, and specifically:

- When valid_until is None, no errors are raised and in the database the role can login until 'infinity'
- When no password is set via Login, then changes to valid_until are correctly applied (and existing password is preserved as before this change)

This is suspected to fix the second issue in https://github.com/uktrade/pg-sync-roles/issues/143