### PR TITLE
fix: remove login password logging

### DIFF
--- a/pg_sync_roles.py
+++ b/pg_sync_roles.py
@@ -95,6 +95,9 @@ class Login:
     valid_until: datetime = None
     password: str = None
 
+    def __str__(self):
+        return f"with password: (redacted) until {self.valid_until}"
+
 
 @dataclass(frozen=True)
 class RoleMembership:


### PR DESCRIPTION
Prevent the login password from being logged on a Login() grant